### PR TITLE
gradle: set jar attributes, main class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,18 @@ repositories {
     mavenCentral()
 }
 
+jar {
+    manifest {
+        attributes 'Main-Class': 'website.nickb.s3ripper.S3Ripper'
+    }
+
+    from {
+        configurations.compile.collect {
+            it.isDirectory() ? it : zipTree(it)
+        }
+    }
+}
+
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }


### PR DESCRIPTION
I noticed the main class was not set so the built .jar did not do anything.

I copied the settings from your https://github.com/nick-botticelli/LIAPPStringDecryptor project.